### PR TITLE
Add WeMos D1 R2 (mini) board

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -52,3 +52,5 @@ board = esp07s
 
 build_dir = build/esp07s
 
+[env:d1_mini]
+board = d1_mini


### PR DESCRIPTION
Adds the WeMos D1 R2 (mini) board to the build process. Platformio documentation:

https://docs.platformio.org/en/latest/boards/espressif8266/d1_mini.html